### PR TITLE
Fix the regular expression matching --

### DIFF
--- a/lib/argsparser.js
+++ b/lib/argsparser.js
@@ -14,7 +14,7 @@ exports.parse = function(args) {
     args.forEach(function(arg) {
         var curValType = typeof opts[curSwitch];
         // its a switch
-        if (/^-|--/.test(arg)) {
+        if (/^(-|--)/.test(arg)) {
             opts[arg] = true;
             curSwitch = arg;
         // this arg is some data

--- a/test/test.js
+++ b/test/test.js
@@ -14,6 +14,8 @@ a.deepEqual(parse(['-o', 'false']), {'-o': false}, 'node script.js -o false');
 
 a.deepEqual(parse(['-o', '123']), {'-o': 123}, 'node script.js -o 123');
 
+a.deepEqual(parse(['--token', 'bla--bla']), {'--token': 'bla--bla'}, 'node script.js --token bla--bla');
+
 a.deepEqual(parse(['-o', '123.456']), {'-o': 123.456}, 'node script.js -o 123.456');
 
 a.deepEqual(parse(['-o', 'test']), {'-o': 'test'}, 'node script.js -o test');
@@ -31,6 +33,5 @@ a.deepEqual(parse(['-paths', '/test.js', '/test1.js']), {'-paths': ['/test.js', 
 a.deepEqual(parse(['--paths', '/test.js', '/test1.js']), {'--paths': ['/test.js', '/test1.js']}, 'node script.js --paths /test.js /test1.js');
 
 a.deepEqual(parse(['--paths', '/test.js', '/test1.js', '-a', 'testa']), {'--paths': ['/test.js', '/test1.js'], '-a': 'testa'}, 'node script.js --paths /test.js /test1.js -a testa');
-
 
 util.print('All tests ok\n');


### PR DESCRIPTION
the regular expression /^-|--/ was matching args that contained -- in any place of the args which lead to strange situations where for example:

node test_args.js --switch bla--bla
returned { node: '/private/tmp/node-argsparser/test_args.js', '--switch': true, 'bla--bla': true }

My commit fixes that.
Regards
Vincent
