### PR TITLE
Addresses bug with array of number argument

### DIFF
--- a/lib/argsparser.js
+++ b/lib/argsparser.js
@@ -29,7 +29,7 @@ exports.parse = function(args) {
 
             if (curValType === 'boolean') {
                 opts[curSwitch] = arg;
-            } else if (curValType === 'string') {
+            } else if (curValType === 'string' || curValType === 'number') {
                 opts[curSwitch] = [opts[curSwitch], arg];
             } else {
                 opts[curSwitch].push(arg);


### PR DESCRIPTION
Fixes bug with array of numbers argument, e.g. `node server.js --port 80 8080`

When executing `node server.js --port 80 8080`, the current version will produce an error `TypeError: Object 80 has no method 'push'`
